### PR TITLE
Drupal 9 deprecation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Localist Events Pull
 
-A Drupal 8 custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type.
+A Drupal 8 / 9 custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type.
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/cubear/cwd_events_localist_pull.svg?style=flat-square)](https://packagist.org/packages/cubear/cwd_events_localist_pull)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cubear/cwd_events_localist_pull",
-    "description": "A Drupal 8 custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type.",
+    "description": "A Drupal 8 or 9 custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type.",
     "type": "drupal-custom-module",
     "license": "GPL-3.0+",
     "homepage": "https://it.cornell.edu/custom-web",

--- a/cwd_events_localist_pull.info.yml
+++ b/cwd_events_localist_pull.info.yml
@@ -2,4 +2,5 @@ name: "Localist Events Pull"
 type: module
 description: "Custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type."
 core: 8.x
+core_version_requirement: ^8 || ^9
 package: Custom

--- a/cwd_events_localist_pull.module
+++ b/cwd_events_localist_pull.module
@@ -30,10 +30,11 @@ function cwd_events_localist_pull_help($route_name, RouteMatchInterface $route_m
 function cwd_events_localist_pull_cron() {
     $query = \Drupal::service('entity.query')->get('localist_pull');
     $entity_ids = $query->execute();
-    $config_storage = \Drupal::entityManager()->getStorage('localist_pull');
+    $config_storage = \Drupal::entityTypeManager()->getStorage('localist_pull');
     $configs = $config_storage->loadMultiple($entity_ids);
+    $file_system = \Drupal::service('file_system');
     foreach ($configs as $config) {
-      $processor = new LocalistProcessor($config);
+      $processor = new LocalistProcessor($config, $file_system);
       $url = $processor->create_localist_url();
       \Drupal::logger('localist_pull')->notice($url);
       $processor->process_url_pull($config->get('localist_id_field_name'),$url);

--- a/src/Form/LocalistDeleteForm.php
+++ b/src/Form/LocalistDeleteForm.php
@@ -37,7 +37,8 @@ class LocalistDeleteForm extends EntityConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
-    drupal_set_message($this->t('Category %label has been deleted.', array('%label' => $this->entity->label())));
+
+    \Drupal::messenger()->addMessage($this->t('Category %label has been deleted.', array('%label' => $this->entity->label())));
 
     $form_state->setRedirectUrl($this->getCancelUrl());
   }

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -299,12 +299,12 @@ class LocalistEntityForm extends EntityForm {
     $status = $localist_pull->save();
     // kint($status);
     if ($status) {
-      drupal_set_message($this->t('Saved the %label localist_pull entity.', [
+      \Drupal::messenger()->addMessage($this->t('Saved the %label localist_pull entity.', [
         '%label' => $localist_pull->label(),
       ]));
     }
     else {
-      drupal_set_message($this->t('The %label localist_pull entity was not saved.', [
+      \Drupal::messenger()->addMessage($this->t('The %label localist_pull entity was not saved.', [
         '%label' => $localist_pull->label(),
       ]));
     }

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -1,5 +1,6 @@
 <?php
 namespace Drupal\cwd_events_localist_pull;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Component\Serialization\Json;
 use \Drupal\node\Entity\Node;
@@ -12,8 +13,14 @@ use Drupal\file\Entity\File;
 class LocalistProcessor {
   private $config;
 
-  public function __construct($provided_config) {
+  /**
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  private $file_system;
+
+  public function __construct($provided_config, FileSystemInterface $file_system) {
     $this->config = $provided_config;
+    $this->file_system = $file_system;
   }
 
   private function get_node_by_localist_id($field_search_name, $id) {
@@ -132,8 +139,8 @@ class LocalistProcessor {
     $photo_name = array_pop($temp);
     $data = file_get_contents($url);
     $path = 'public://localist';
-    file_prepare_directory($path, FILE_CREATE_DIRECTORY);
-    $file = file_save_data($data, 'public://localist/'.$photo_name, FILE_EXISTS_REPLACE);
+    $this->file_system->prepareDirectory($path, FileSystemInterface::CREATE_DIRECTORY);
+    $file = file_save_data($data, $path .'/'. $photo_name, FileSystemInterface::EXISTS_REPLACE);
     $photo_array = [
       'target_id' => $file->id(),
       'alt' => '',


### PR DESCRIPTION
Addresses items found using drupal/upgrade_status and reported in #15.

The upgrade_status scan reported no known issues on the module after these updates. While that doesn't guarantee D9 compatibility, it's a good start.

Note: I didn't add an explicit drupal/core ^8.7.7 || ^9.0 composer requirement, but that may be a good idea?

Closes #15.

----
_UPDATE (Alison here)_
**Next steps:**
* [ ] Code review
* [ ] Put drupal9 branch of this module on a CD Demo multidev -- it'll be testing it on a D8 site with an existing install of the module, but still something we need to do:
`composer require cubear/cwd_events_localist_pull:dev-drupal9`
  * Check upgrade status against the issues listed in #15
  * Test module functionality
* [ ] Test on a D9 site (@ssh6 says he'll see if he can help us with this item)