### PR TITLE
support event types + fix notices

### DIFF
--- a/config/schema/localistconfig.schema.yml
+++ b/config/schema/localistconfig.schema.yml
@@ -52,13 +52,19 @@ cwd_events_localist_pull.localist_pull.*:
       label: 'Localist event image'
     localist_tag_field_name:
       type: string
-      label: 'Localist event department tags'
+      label: 'Localist event department field'
     localist_department_taxonomy:
       type: string
       label: 'Department taxonomy'
     localist_department_lookup_field:
       type: string
       label: 'Department lookup field'
+    localist_event_type_field_name:
+      type: string
+      label: 'Event type field'
+    localist_event_type_taxonomy:
+      type: string
+      label: 'Event type taxonomy'
     update_events_bool:
       type: boolean
       label: 'Should we update existing events'

--- a/src/Entity/LocalistConfig.php
+++ b/src/Entity/LocalistConfig.php
@@ -44,6 +44,8 @@ use Drupal\cwd_events_localist_pull\LocalistInterface;
  *     "localist_tag_field_name",
  *     "localist_department_taxonomy",
  *     "localist_department_lookup_field",
+ *     "localist_event_type_taxonomy",
+ *     "localist_event_type_field_name",
  *     "update_events_bool",
  *     "publish_events_bool",
  *     "pull_specified_departments",
@@ -200,5 +202,17 @@ class LocalistConfig extends ConfigEntityBase implements LocalistInterface {
   * @var boolean
   */
   public $extra_parameters;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_event_type_taxonomy;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_event_type_field_name;
 
 }

--- a/src/Entity/LocalistConfig.php
+++ b/src/Entity/LocalistConfig.php
@@ -163,4 +163,42 @@ class LocalistConfig extends ConfigEntityBase implements LocalistInterface {
   * @var boolean
   */
   public $publish_events_bool;
+
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_tag_field_name;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_department_taxonomy;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_department_lookup_field;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $pull_specified_departments;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $localist_relative_date;
+  /**
+  * The localist_pull entity url.
+  *
+  * @var boolean
+  */
+  public $extra_parameters;
+
 }

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -242,8 +242,8 @@ class LocalistEntityForm extends EntityForm {
     ];
     $form['department_label'] = array(
       '#type' => 'label',
-      '#title' => $this->t('<br/><hr/><h2>Department Taxonomy</h2><hr/>
-       Instructions:
+      '#title' => $this->t('<br/><hr/><h2>Taxonomy</h2><hr/>
+       Instructions for departments: (TO DO: instructions for event types)
         <ul>
           <li>If you want to feed in localist departments fill in the machine name of the taxonomy that should hold localist departments.</li>
           <li>If you do not plan to edit these localist department names leave the Department Term lookup blank. We will lookup by term name.</li>
@@ -282,9 +282,24 @@ class LocalistEntityForm extends EntityForm {
       '#title' => $this->t('Should we pull only the specified departments as tags? By not checking this box we will pull all departments on an event.'),
       '#default_value' => $localist_pull->pull_specified_departments,
     ];
-
-
-
+    $form['localist_event_type_taxonomy'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Taxonomy for Event type terms'),
+      '#default_value' => $localist_pull->localist_event_type_taxonomy,
+      '#size' => 20,
+      '#maxlength' => 255,
+      '#description' => $this->t('Machine name of the taxonomy to feed localist event types.'),
+      '#required' => FALSE,
+    ];
+    $form['localist_event_type_field_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Event CT field for Localist event_types'),
+      '#default_value' => $localist_pull->localist_event_type_field_name,
+      '#size' => 20,
+      '#maxlength' => 255,
+      '#description' => $this->t('Mapping: event type term reference field machine name.'),
+      '#required' => FALSE,
+    ];
 
     // You will need additional form elements for your custom properties.
     return $form;

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -242,8 +242,8 @@ class LocalistEntityForm extends EntityForm {
     ];
     $form['department_label'] = array(
       '#type' => 'label',
-      '#title' => $this->t('<br/><hr/><h2>Taxonomy</h2><hr/>
-       Instructions for departments: (TO DO: instructions for event types)
+      '#title' => $this->t('<br/><hr/><h2>Taxonomy</h2>
+       Instructions for departments:
         <ul>
           <li>If you want to feed in localist departments fill in the machine name of the taxonomy that should hold localist departments.</li>
           <li>If you do not plan to edit these localist department names leave the Department Term lookup blank. We will lookup by term name.</li>
@@ -282,6 +282,11 @@ class LocalistEntityForm extends EntityForm {
       '#title' => $this->t('Should we pull only the specified departments as tags? By not checking this box we will pull all departments on an event.'),
       '#default_value' => $localist_pull->pull_specified_departments,
     ];
+    $form['etypes_label'] = array(
+      '#type' => 'label',
+      '#title' => $this->t('<h3>Event types</h3>
+       Less complex than departments: Simply enter the taxonomy machine name and event CT field for event type terms.'),
+    );
     $form['localist_event_type_taxonomy'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Taxonomy for Event type terms'),


### PR DESCRIPTION
Ready for review on https://alison-cd-demo.pantheonsite.io/
* I configured the importer to put event types into the tags vocab and field_tags -- it's not being output anywhere right now, but you can see the values by editing event nodes and looking at the tags vocab:
  * [List of event nodes](https://alison-cd-demo.pantheonsite.io/admin/content?title=&type=event&status=All&langcode=All&items_per_page=50)
  * [Tags vocabulary](https://alison-cd-demo.pantheonsite.io/admin/structure/taxonomy/manage/tags/overview) with event types that were automatically generated by the localist importer

----
Event types support:
Will we decide to get fancier and do it more flexibly like "put your localist field machine name here and your drupal field machine name here oh and also if it's a taxonomy term field put your vocab info over here"......... sure yeah totally maybe ¯\_(ツ)_/¯ .......but meanwhile.......