### PR TITLE
Fix checking for existing Node(event)

### DIFF
--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -291,7 +291,6 @@ class LocalistProcessor {
         }
         \Drupal::logger('localist_pull')->notice("process page $current_page of $total_pages");
         if(!empty($events)) {
-          $count = 0;
           foreach ($events as $event) {
             $localist_data_array = $this->get_localist_event_data($event,$this->create_node_create_array());
             $existing_event = $this->get_node_by_localist_id($search_field_name,$event['event']['id']);

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -1,12 +1,13 @@
 <?php
+
 namespace Drupal\cwd_events_localist_pull;
+
 use Drupal\Core\File\FileSystemInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Component\Serialization\Json;
 use \Drupal\node\Entity\Node;
 use Drupal\taxonomy\Entity\Term;
+use GuzzleHttp\Exception\RequestException;
 
-use Drupal\file\Entity\File;
 /**
  * Provides an interface defining an localist_pull entity entity.
  */
@@ -24,10 +25,13 @@ class LocalistProcessor {
   }
 
   private function get_node_by_localist_id($field_search_name, $id) {
-    $conf_id = $this->config->id;
-    $query = \Drupal::entityQuery('node')->condition($field_search_name, $conf_id.$id);
-    $nids = $query->execute();
-    return $nids;
+    $event_id = $this->config->id . $id;
+    $database = \Drupal::database();
+    $query = $database->select('node', 'n');
+    $query->innerJoin("node__{$field_search_name}", 'lid', 'lid.entity_id=n.nid');
+    $query->addField('n', 'nid');
+    $query->condition("lid.{$field_search_name}_value", $event_id);
+    return $query->execute()->fetchCol();
   }
 
   private function convert_localist_date($date_string) {
@@ -248,7 +252,6 @@ class LocalistProcessor {
       } else {
         $events = Json::decode($json)['events'];
         if(!empty($events)) {
-          $count = 0;
           foreach ($events as $event) {
             $localist_data_array = $this->get_localist_event_data($event,$this->create_node_create_array());
             $existing_event = $this->get_node_by_localist_id($search_field_name,$event['event']['id']);
@@ -262,9 +265,8 @@ class LocalistProcessor {
               $node->save();
             } else {
               if($this->config->update_events_bool) {
-                $temp = array_reverse($existing_event);
-                $existing_node_id = array_pop($temp);
-                $node = Node::load($existing_node_id);
+                $nid = reset($existing_event);
+                $node = Node::load($nid);
                 foreach ($localist_data_array as $key => $value) {
                   if($key != 'type') {
                     $node->set($key,$value);
@@ -278,7 +280,7 @@ class LocalistProcessor {
       }
     }
     catch (RequestException $e) {
-      \Drupal::logger('localist_pull')->notice("exception");
+      \Drupal::logger('localist_pull')->error($e->getMessage());
       return FALSE;
     }
   }

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -291,6 +291,7 @@ class LocalistProcessor {
         }
         \Drupal::logger('localist_pull')->notice("process page $current_page of $total_pages");
         if(!empty($events)) {
+          $count = 0;
           foreach ($events as $event) {
             $localist_data_array = $this->get_localist_event_data($event,$this->create_node_create_array());
             $existing_event = $this->get_node_by_localist_id($search_field_name,$event['event']['id']);


### PR DESCRIPTION
**Goal**
This PR addresses the issue which creates duplicate Events on `ovpia-is` where we have the config as:

> Update all existing events: TRUE
> Publish all new events: FALSE

**Symptoms**
In the context of Cron and/or calling in a plain PHP Class(not a Drupal service with dependency injection) performing a query via Entity Storage always return no results(`LocalistProcessor::get_node_by_localist_id`).

**Proposed solution**
Use directly `\Drupal::database()` - which proves to work correctly now.

**Original support request from Brad Alderman**

On International Services, the Localist pull is duplicating events instead of updating existing. I feel like this has popped up before, but I don’t remember what the fix was. The event pull on this site is set to bring these in as unpublished content, so the duplicated events aren’t showing up on the front end, just in the backend content listing.

[Problem started when old localist_pull module was replaced by cwd_events_localist_pull]