### PR TITLE
Pagination and image url bug fix

### DIFF
--- a/cwd_events_localist_pull.module
+++ b/cwd_events_localist_pull.module
@@ -38,7 +38,6 @@ function cwd_events_localist_pull_cron() {
     foreach ($configs as $config) {
       $processor = new LocalistProcessor($config, $file_system);
       $url = $processor->create_localist_url();
-      \Drupal::logger('localist_pull')->notice($url);
       $processor->process_url_pull($config->get('localist_id_field_name'),$url);
     }
 

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -148,6 +148,7 @@ class LocalistProcessor {
 
   private function create_file_and_array($url) {
     $temp = explode('/',$url);
+    $url = str_replace("https:","http:",$url);
     $photo_name = array_pop($temp);
     $data = file_get_contents($url);
     $path = 'public://localist';


### PR DESCRIPTION
 - Fix file_get_contents() warning/error
 --  Change image file url from https to http to fix openssl error/warning pulling file.

- Fix pagination issue
-- When a page returns no results cron can continue to keep pulling an infinite number of pages causing issues. Fix so that if no events returned on a page don't try to pull the next one.