### PR TITLE
update core_version_requirement for Drupal 10

### DIFF
--- a/cwd_events_localist_pull.info.yml
+++ b/cwd_events_localist_pull.info.yml
@@ -1,5 +1,5 @@
 name: "CWD Localist Events Importer"
 type: module
 description: "Custom module to import events from localist (CU Calendar, Weill Calendar, etc.) into nodes of a specified content type."
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^9 || ^10
 package: Custom


### PR DESCRIPTION
Upgrade Status doesn't report any D10 compatibility blockers for this module other than the core_version_requirement thing -- so far.