### PR TITLE
add images as media (applying media field work to new branch off 3.0)

### DIFF
--- a/config/schema/localistconfig.schema.yml
+++ b/config/schema/localistconfig.schema.yml
@@ -55,7 +55,7 @@ cwd_events_localist_pull.localist_pull.*:
       label: 'Localist event image'
     localist_media_field_name:
       type: string
-      label: 'Localist event media
+      label: 'Localist event media'
     localist_tag_field_name:
       type: string
       label: 'Localist event department field'

--- a/config/schema/localistconfig.schema.yml
+++ b/config/schema/localistconfig.schema.yml
@@ -53,6 +53,9 @@ cwd_events_localist_pull.localist_pull.*:
     localist_image_field_name:
       type: string
       label: 'Localist event image'
+    localist_media_field_name:
+      type: string
+      label: 'Localist event media
     localist_tag_field_name:
       type: string
       label: 'Localist event department field'

--- a/src/Entity/LocalistConfig.php
+++ b/src/Entity/LocalistConfig.php
@@ -42,6 +42,7 @@ use Drupal\cwd_events_localist_pull\LocalistInterface;
  *     "localist_end_date_field_name",
  *     "localist_description_field_name",
  *     "localist_image_field_name",
+ *     "localist_media_field_name",
  *     "localist_tag_field_name",
  *     "localist_department_taxonomy",
  *     "localist_department_lookup_field",
@@ -82,144 +83,151 @@ class LocalistConfig extends ConfigEntityBase implements LocalistInterface {
   public $url;
 
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_departments;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_keywords;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_count;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_page_count;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_date;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $event_machine_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_id_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_url_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_location_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_date_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_end_date_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_description_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var string
-  */
+   * The localist_pull entity url.
+   *
+   * @var string
+   */
   public $localist_image_field_name;
 
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   *
+   * the localist_pull media field name.
+   * @var string
+   */
+  public $localist_media_field_name;
+
+  /**
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $update_events_bool;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $publish_events_bool;
 
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_tag_field_name;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_department_taxonomy;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_department_lookup_field;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $pull_specified_departments;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_relative_date;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $extra_parameters;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_event_type_taxonomy;
   /**
-  * The localist_pull entity url.
-  *
-  * @var boolean
-  */
+   * The localist_pull entity url.
+   *
+   * @var boolean
+   */
   public $localist_event_type_field_name;
 
 }

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -109,8 +109,8 @@ class LocalistEntityForm extends EntityForm {
     $form['extra_parameters_type'] = array(
       '#type' => 'value',
       '#value' => array('none' => t('None'),
-      'distinct' => t('Distinct'),
-      'all' => t('All Instances'))
+        'distinct' => t('Distinct'),
+        'all' => t('All Instances'))
     );
     $form['extra_parameters'] = array(
       '#title' => t('Extra Localist URL Parameter'),
@@ -152,12 +152,12 @@ class LocalistEntityForm extends EntityForm {
       '#type' => 'label',
       '#title' => $this->t('<br/><hr/><h2>How events are imported:</h2><hr/>'),
     );
-    $form['update_events_bool'] =[
+    $form['update_events_bool'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Update all existing events'),
       '#default_value' => $localist_pull->update_events_bool,
     ];
-    $form['publish_events_bool'] =[
+    $form['publish_events_bool'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Publish all new events'),
       '#default_value' => $localist_pull->publish_events_bool,
@@ -240,13 +240,13 @@ class LocalistEntityForm extends EntityForm {
       '#required' => FALSE,
     ];
 
-    $form['localist_image_field_name'] = [
+    $form['localist_media_field_name'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Localist event image field'),
-      '#default_value' => $localist_pull->localist_image_field_name,
+      '#title' => $this->t('Localist event media field'),
+      '#default_value' => $localist_pull->localist_media_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist image'),
+      '#description' => $this->t('Mapping: field machine name for the localist media'),
       '#required' => FALSE,
     ];
     $form['department_label'] = array(
@@ -286,7 +286,7 @@ class LocalistEntityForm extends EntityForm {
       '#description' => $this->t('Machine name of the taxonomy field to search for tax term in Drupal taxonomy that maps to localist department'),
       '#required' => FALSE,
     ];
-    $form['pull_specified_departments'] =[
+    $form['pull_specified_departments'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Should we pull only the specified departments as tags? By not checking this box we will pull all departments on an event.'),
       '#default_value' => $localist_pull->pull_specified_departments,

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -102,7 +102,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_page_count,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Enter the number events pages you want to process. Max is 3'),
+      '#description' => $this->t('Enter the number of pages of events you want to process. Max is 3.'),
       '#required' => FALSE,
     ];
 
@@ -124,7 +124,7 @@ class LocalistEntityForm extends EntityForm {
       '#type' => 'label',
       '#title' => $this->t('<br/>Date instructions:
         <ul>
-          <li>Relative date  will be used if filled in</li>
+          <li>Relative date will be used if filled in</li>
           <li>If relative date is blank this connection will use the static date</li>
           <li>If there is no static date the default is today</li>
         </ul>'),
@@ -173,7 +173,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->event_machine_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Machine name of the content type that localist will feed into'),
+      '#description' => $this->t('Machine name of the content type that localist will feed into.'),
       '#required' => FALSE,
     ];
     $form['localist_id_field_name'] = [
@@ -182,7 +182,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_id_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event id'),
+      '#description' => $this->t('Mapping: field machine name for the localist event id.'),
       '#required' => FALSE,
     ];
     $form['localist_url_field_name'] = [
@@ -191,7 +191,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_url_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event URL'),
+      '#description' => $this->t('Mapping: field machine name for the localist event URL.'),
       '#required' => FALSE,
     ];
     $form['localist_location_field_name'] = [
@@ -200,7 +200,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_location_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event location'),
+      '#description' => $this->t('Mapping: field machine name for the localist event location.'),
       '#required' => FALSE,
     ];
     $form['localist_date_field_name'] = [
@@ -209,7 +209,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_date_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event date and time'),
+      '#description' => $this->t('Mapping: field machine name for the localist event date and time.'),
       '#required' => FALSE,
     ];
     $form['localist_end_date_field_name'] = [
@@ -218,7 +218,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_end_date_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event end date and time'),
+      '#description' => $this->t('Mapping: field machine name for the localist event end date and time.'),
       '#required' => FALSE,
     ];
     $form['localist_description_field_name'] = [
@@ -227,7 +227,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_description_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist event discription'),
+      '#description' => $this->t('Mapping: field machine name for the localist event discription.'),
       '#required' => FALSE,
     ];
     $form['localist_image_field_name'] = [
@@ -236,7 +236,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_image_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist image'),
+      '#description' => $this->t('Mapping: field machine name for the localist image.'),
       '#required' => FALSE,
     ];
 
@@ -246,7 +246,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_media_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist media. Importer expects the media field to reference a media bundle called "image" with an image file field called "field_media_image"'),
+      '#description' => $this->t('Mapping: field machine name for the localist media. Importer expects the media field to reference a media bundle called "image" with an image file field called "field_media_image".'),
       '#required' => FALSE,
     ];
     $form['department_label'] = array(
@@ -265,7 +265,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_department_taxonomy,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Machine name of the taxonomy to feed localist departments'),
+      '#description' => $this->t('Machine name of the taxonomy to feed localist departments.'),
       '#required' => FALSE,
     ];
     $form['localist_tag_field_name'] = [
@@ -283,7 +283,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_department_lookup_field,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Machine name of the taxonomy field to search for tax term in Drupal taxonomy that maps to localist department'),
+      '#description' => $this->t('Machine name of the taxonomy field to search for tax term in Drupal taxonomy that maps to localist department.'),
       '#required' => FALSE,
     ];
     $form['pull_specified_departments'] = [

--- a/src/Form/LocalistEntityForm.php
+++ b/src/Form/LocalistEntityForm.php
@@ -246,7 +246,7 @@ class LocalistEntityForm extends EntityForm {
       '#default_value' => $localist_pull->localist_media_field_name,
       '#size' => 20,
       '#maxlength' => 255,
-      '#description' => $this->t('Mapping: field machine name for the localist media'),
+      '#description' => $this->t('Mapping: field machine name for the localist media. Importer expects the media field to reference a media bundle called "image" with an image file field called "field_media_image"'),
       '#required' => FALSE,
     ];
     $form['department_label'] = array(

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -179,6 +179,16 @@ class LocalistProcessor {
     return $media->id();
   }
 
+  private function find_media_for_file($image_array) {
+    $file = \Drupal::entityTypeManager()->getStorage('file')->load($image_array['target_id']);
+    $result = \Drupal::service('file.usage')->listUsage($file);
+    if (array_key_exists('media', $result['file'])) {
+      return array_key_first($result['file']['media']);
+    }
+    else {
+      return null;
+    }
+  }
   private function create_file_and_array($url) {
     $temp = explode('/', $url);
     $url = str_replace("https:", "http:", $url);

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -32,18 +32,22 @@ class LocalistProcessor {
     $query->addField('n', 'nid');
     $query->condition("lid.{$field_search_name}_value", $event_id);
     return $query->execute()->fetchCol();
+    // $conf_id = $this->config->id;
+    // $query = \Drupal::entityQuery('node')->condition($field_search_name, $conf_id . $id);
+    // $nids = $query->execute();
+    // return $nids;
   }
 
   private function convert_localist_date($date_string) {
-    $cut_date_string = substr($date_string,0,-6);
-    $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:s',date("Y-m-d\TH:i:s",strtotime($cut_date_string)));
-    $sign = substr($date_string,-6,1);
+    $cut_date_string = substr($date_string, 0, -6);
+    $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:s', date("Y-m-d\TH:i:s", strtotime($cut_date_string)));
+    $sign = substr($date_string, -6, 1);
     $offset_sign = "+";
-    if($sign == "+") {
+    if ($sign == "+") {
       $offset_sign = "-";
     }
-    $offset_hours = ltrim(substr($date_string,-5,2), '0');
-    $offset = $offset_sign.$offset_hours." hours";
+    $offset_hours = ltrim(substr($date_string, -5, 2), '0');
+    $offset = $offset_sign . $offset_hours . " hours";
     $dateTime = $dateTime->modify($offset);
     $newdate = $dateTime->format('Y-m-d\TH:i:s');
     return $newdate;
@@ -51,31 +55,34 @@ class LocalistProcessor {
 
   private function create_node_create_array() {
     $node_create_array = [];
-    if(!empty($this->config->get('localist_id_field_name')) && $this->config->get('localist_id_field_name') != '') {
+    if (!empty($this->config->get('localist_id_field_name')) && $this->config->get('localist_id_field_name') != '') {
       $node_create_array[$this->config->get('localist_id_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_url_field_name')) && $this->config->get('localist_url_field_name') != '') {
+    if (!empty($this->config->get('localist_url_field_name')) && $this->config->get('localist_url_field_name') != '') {
       $node_create_array[$this->config->get('localist_url_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_location_field_name')) && $this->config->get('localist_location_field_name') != '') {
+    if (!empty($this->config->get('localist_location_field_name')) && $this->config->get('localist_location_field_name') != '') {
       $node_create_array[$this->config->get('localist_location_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_date_field_name')) && $this->config->get('localist_date_field_name') != '') {
+    if (!empty($this->config->get('localist_date_field_name')) && $this->config->get('localist_date_field_name') != '') {
       $node_create_array[$this->config->get('localist_date_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_end_date_field_name')) && $this->config->get('localist_end_date_field_name') != '') {
+    if (!empty($this->config->get('localist_end_date_field_name')) && $this->config->get('localist_end_date_field_name') != '') {
       $node_create_array[$this->config->get('localist_end_date_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_description_field_name')) && $this->config->get('localist_description_field_name') != '') {
+    if (!empty($this->config->get('localist_description_field_name')) && $this->config->get('localist_description_field_name') != '') {
       $node_create_array[$this->config->get('localist_description_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_image_field_name')) && $this->config->get('localist_image_field_name') != '') {
+    if (!empty($this->config->get('localist_image_field_name')) && $this->config->get('localist_image_field_name') != '') {
       $node_create_array[$this->config->get('localist_image_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_tag_field_name')) && $this->config->get('localist_tag_field_name') != '') {
+    if (!empty($this->config->get('localist_media_field_name')) && $this->config->get('localist_media_field_name') != '') {
+      $node_create_array[$this->config->get('localist_media_field_name')] = '';
+    }
+    if (!empty($this->config->get('localist_tag_field_name')) && $this->config->get('localist_tag_field_name') != '') {
       $node_create_array[$this->config->get('localist_tag_field_name')] = '';
     }
-    if(!empty($this->config->get('localist_event_type_field_name')) && $this->config->get('localist_event_type_field_name') != '') {
+    if (!empty($this->config->get('localist_event_type_field_name')) && $this->config->get('localist_event_type_field_name') != '') {
       $node_create_array[$this->config->get('localist_event_type_field_name')] = '';
     }
     return $node_create_array;
@@ -87,44 +94,51 @@ class LocalistProcessor {
       switch ($fieldname) {
         case $this->config->get('localist_id_field_name'):
           $conf_id = $this->config->id;
-          $new_array[$this->config->get('localist_id_field_name')]=$conf_id.$event['event']['id'];
+          $new_array[$this->config->get('localist_id_field_name')] = $conf_id . $event['event']['id'];
           break;
         case $this->config->get('localist_date_field_name'):
-          if(!is_null($event['event']['event_instances']['0']['event_instance']['start'])) {
-            $new_array[$this->config->get('localist_date_field_name')]=$this->convert_localist_date($event['event']['event_instances']['0']['event_instance']['start']);
+          if (!is_null($event['event']['event_instances']['0']['event_instance']['start'])) {
+            $new_array[$this->config->get('localist_date_field_name')] = $this->convert_localist_date($event['event']['event_instances']['0']['event_instance']['start']);
             // \Drupal::logger('localist_pull')->notice($event['event']['title']." START: ".$event['event']['event_instances']['0']['event_instance']['start']." Returned: ".$new_array[$config->get('localist_date_field_name')]);
           }
           break;
         case $this->config->get('localist_end_date_field_name'):
-          if(!is_null($event['event']['event_instances']['0']['event_instance']['end'])) {
-            $new_array[$this->config->get('localist_end_date_field_name')]=$this->convert_localist_date($event['event']['event_instances']['0']['event_instance']['end']);
+          if (!is_null($event['event']['event_instances']['0']['event_instance']['end'])) {
+            $new_array[$this->config->get('localist_end_date_field_name')] = $this->convert_localist_date($event['event']['event_instances']['0']['event_instance']['end']);
             // \Drupal::logger('localist_pull')->notice($event['event']['title']." END: ".$event['event']['event_instances']['0']['event_instance']['end']." Returned: ".$new_array[$config->get('localist_end_date_field_name')]);
           }
           break;
         case $this->config->get('localist_description_field_name'):
-          $new_array[$this->config->get('localist_description_field_name')]=$event['event']['description_text'];
+          $new_array[$this->config->get('localist_description_field_name')] = $event['event']['description_text'];
           break;
         case $this->config->get('localist_location_field_name'):
-          if(!empty($event['event']['location_name']) && !is_null($event['event']['location_name']) && !empty($event['event']['room_number']) && !is_null($event['event']['room_number']))
-            $new_array[$this->config->get('localist_location_field_name')]=$event['event']['location_name'].", ".$event['event']['room_number'];
+          if (!empty($event['event']['location_name']) && !is_null($event['event']['location_name']) && !empty($event['event']['room_number']) && !is_null($event['event']['room_number']))
+            $new_array[$this->config->get('localist_location_field_name')] = $event['event']['location_name'] . ", " . $event['event']['room_number'];
           else
-            $new_array[$this->config->get('localist_location_field_name')]=$event['event']['location_name'];
+            $new_array[$this->config->get('localist_location_field_name')] = $event['event']['location_name'];
           break;
         case $this->config->get('localist_url_field_name'):
-          $new_array[$this->config->get('localist_url_field_name')]=$event['event']['localist_url'];
+          $new_array[$this->config->get('localist_url_field_name')] = $event['event']['localist_url'];
           break;
         case $this->config->get('localist_image_field_name'):
-          if(!empty($event['event']['photo_url']) && $event['event']['photo_url'] != '') {
-            $new_array[$this->config->get('localist_image_field_name')]=$this->create_file_and_array($event['event']['photo_url']);
+          if (!empty($event['event']['photo_url']) && $event['event']['photo_url'] != '') {
+            $new_array[$this->config->get('localist_image_field_name')] = $this->create_file_and_array($event['event']['photo_url']);
+          }
+          break;
+        case $this->config->get('localist_media_field_name'):
+          if (!empty($event['event']['photo_url']) && $event['event']['photo_url'] != '') {
+            $image_array = $this->create_file_and_array($event['event']['photo_url']);
+            $media_name = "Event Image: " . $event['event']['title'];
+            $new_array[$this->config->get('localist_media_field_name')] = $this->create_media_from_file($image_array, $media_name);
           }
           break;
         case $this->config->get('localist_tag_field_name'):
-          if(!empty($event['event']['filters']['departments']) && $event['event']['filters']['departments'] != '') {
+          if (!empty($event['event']['filters']['departments']) && $event['event']['filters']['departments'] != '') {
             $pull_specified_departments = $this->config->get('pull_specified_departments');
-            $valid_department_array = explode(",",$this->config->get('localist_departments'));
+            $valid_department_array = explode(",", $this->config->get('localist_departments'));
             $department_term_array = array();
             foreach ($event['event']['filters']['departments'] as $department_info) {
-              if($pull_specified_departments && !in_array($department_info['id'],$valid_department_array)) {
+              if ($pull_specified_departments && !in_array($department_info['id'], $valid_department_array)) {
                 continue;
               }
               $department_term_array[] = ['target_id' => $this->find_or_create_department($department_info['name'])];
@@ -133,7 +147,7 @@ class LocalistProcessor {
           }
           break;
         case $this->config->get('localist_event_type_field_name'):
-          if(!empty($event['event']['filters']['event_types']) && $event['event']['filters']['event_types'] != '') {
+          if (!empty($event['event']['filters']['event_types']) && $event['event']['filters']['event_types'] != '') {
             $event_type_term_array = array();
             foreach ($event['event']['filters']['event_types'] as $event_type_info) {
               $event_type_term_array[] = ['target_id' => $this->find_or_create_event_type($event_type_info['name'])];
@@ -143,21 +157,36 @@ class LocalistProcessor {
           break;
       }
     }
-    $new_array['title']=$event['event']['title'];
-    $new_array['type']=$this->config->get('event_machine_name');
+    $new_array['title'] = $event['event']['title'];
+    $new_array['type'] = $this->config->get('event_machine_name');
     unset($new_array['']);
     return $new_array;
   }
 
 
+  private function create_media_from_file($image_array, $media_name) {
+    $media_id = $this->find_media_for_file($image_array);
+    if ($media_id) {
+      return $media_id;
+    }
+
+    $media = Media::create([
+      'bundle' => 'image',
+      'uid' => 1,
+      'field_media_image' => $image_array,
+    ]);
+    $media->setName($media_name)->setPublished()->save();
+    return $media->id();
+  }
+
   private function create_file_and_array($url) {
-    $temp = explode('/',$url);
-    $url = str_replace("https:","http:",$url);
+    $temp = explode('/', $url);
+    $url = str_replace("https:", "http:", $url);
     $photo_name = array_pop($temp);
     $data = file_get_contents($url);
     $path = 'public://localist';
     $this->file_system->prepareDirectory($path, FileSystemInterface::CREATE_DIRECTORY);
-    $file = file_save_data($data, $path .'/'. $photo_name, FileSystemInterface::EXISTS_REPLACE);
+    $file = file_save_data($data, $path . '/' . $photo_name, FileSystemInterface::EXISTS_REPLACE);
     $photo_array = [
       'target_id' => $file->id(),
       'alt' => '',
@@ -171,28 +200,30 @@ class LocalistProcessor {
     $tax_search_field = $this->config->get('localist_department_lookup_field');
 
     $term = null;
-    if($tax_search_field != '') {
-      $term_id = $this->getTermByField($tax_search_field,$term_name);
-      if($term_id != false) {
+    if ($tax_search_field != '') {
+      $term_id = $this->getTermByField($tax_search_field, $term_name);
+      if ($term_id != false) {
         return $term_id;
-      } else {
-        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name,'vid' => $tax_vid]);
       }
-    } else {
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name,'vid' => $tax_vid]);
+      else {
+        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name, 'vid' => $tax_vid]);
+      }
+    }
+    else {
+      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name, 'vid' => $tax_vid]);
     }
 
-    if(empty($term) || is_null($term)) {
+    if (empty($term) || is_null($term)) {
       $new_term = Term::create([
         'vid' => $tax_vid,
         'name' => $term_name,
       ]);
-      if($tax_search_field != '') {
-        $new_term->set($tax_search_field,$term_name);
+      if ($tax_search_field != '') {
+        $new_term->set($tax_search_field, $term_name);
       }
       $new_term->enforceIsNew();
       $new_term->save();
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name,'vid' => $tax_vid]);
+      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name, 'vid' => $tax_vid]);
     }
     return array_shift($term)->id();
   }
@@ -201,114 +232,123 @@ class LocalistProcessor {
     $tax_vid = $this->config->get('localist_event_type_taxonomy');
 
     $term = null;
-    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name,'vid' => $tax_vid]);
+    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name, 'vid' => $tax_vid]);
 
-    if(empty($term) || is_null($term)) {
+    if (empty($term) || is_null($term)) {
       $new_term = Term::create([
         'vid' => $tax_vid,
         'name' => $term_name,
       ]);
       $new_term->enforceIsNew();
       $new_term->save();
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name,'vid' => $tax_vid]);
+      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['name' => $term_name, 'vid' => $tax_vid]);
     }
     return array_shift($term)->id();
   }
 
-  protected function getTermByField($tax_search_field,$term_name) {
+  protected function getTermByField($tax_search_field, $term_name) {
     $query_string = "select taxonomy_term_field_data.tid";
-    $query_string .= " from taxonomy_term_field_data, taxonomy_term__".$tax_search_field;
-    $query_string .= " where taxonomy_term_field_data.tid = taxonomy_term__".$tax_search_field.".entity_id";
-    $query_string .= " and taxonomy_term__".$tax_search_field.".".$tax_search_field."_value = '".$term_name."'";
-    $query_string .=" limit 1;";
+    $query_string .= " from taxonomy_term_field_data, taxonomy_term__" . $tax_search_field;
+    $query_string .= " where taxonomy_term_field_data.tid = taxonomy_term__" . $tax_search_field . ".entity_id";
+    $query_string .= " and taxonomy_term__" . $tax_search_field . "." . $tax_search_field . "_value = '" . $term_name . "'";
+    $query_string .= " limit 1;";
     $database = \Drupal::database();
     $query = $database->query($query_string);
     $results = $query->fetchAll();
-    if(count($results) == 0) {
+    if (count($results) == 0) {
       //if no results then send back false
       return false;
-    } else {
+    }
+    else {
       return array_shift($results)->tid;
     }
   }
 
-  public function create_localist_url($page = 1){
+  public function create_localist_url($page = 1) {
     $uri = $this->config->get('url');
-    $keys = str_replace(' ','+',implode('&keyword[]=',explode(',',$this->config->get('localist_keywords'))));
-    if(!is_null($keys) && $keys != '') {
-        $keys = "&keyword[]=".$keys;
+    $keys = str_replace(' ', '+', implode('&keyword[]=', explode(',', $this->config->get('localist_keywords'))));
+    if (!is_null($keys) && $keys != '') {
+      $keys = "&keyword[]=" . $keys;
     }
-    $depts = str_replace(' ','+',implode('&type[]=',explode(',',$this->config->get('localist_departments'))));
-    if(!is_null($depts) && $depts != '') {
-        $depts = "&type[]=".$depts;
+    $depts = str_replace(' ', '+', implode('&type[]=', explode(',', $this->config->get('localist_departments'))));
+    if (!is_null($depts) && $depts != '') {
+      $depts = "&type[]=" . $depts;
     }
 
     //Date for localist url (bad dates)
     $date = $this->config->get('localist_relative_date');
     //if relative date is empty use fixed date.
-    if(is_null($date) || $date == '') {
+    if (is_null($date) || $date == '') {
       $date = $this->config->get('localist_date');
       //if fixed date is empty use today.
-      if(is_null($date) || $date == '') {
-          $date = date('Y-m-d');
+      if (is_null($date) || $date == '') {
+        $date = date('Y-m-d');
       }
-    } else {
+    }
+    else {
       //construct relative date
-      $date =  date('Y-m-d', strtotime($date));
+      $date = date('Y-m-d', strtotime($date));
     }
 
     $count = $this->config->get('localist_count');
-    if(is_null($count) || $count == '') {
-        $count = '5';
+    if (is_null($count) || $count == '') {
+      $count = '5';
     }
     $extra_param = $this->config->get('extra_parameters');
-    if($extra_param == "distinct") {
+    if ($extra_param == "distinct") {
       $extra_param = "&distinct=true";
-    } elseif($extra_param == "all") {
+    }
+    elseif ($extra_param == "all") {
       $extra_param = "&all_instances=true";
-    } else {
+    }
+    else {
       $extra_param = "";
     }
-    $url = $uri.'&days=370&sort=date'.$keys.$depts.'&pp='.$count.'&start='.$date.$extra_param."&page=$page";
+    $url = $uri . '&days=370&sort=date' . $keys . $depts . '&pp=' . $count . '&start=' . $date . $extra_param . "&page=$page";
     return $url;
   }
 
 
-  public function process_url_pull($search_field_name,$url) {
+  public function process_url_pull($search_field_name, $url) {
     try {
       \Drupal::logger('localist_pull')->notice($url);
       $response = \Drupal::httpClient()->get($url, array('headers' => array('Accept' => 'text/plain')));
       $json = (string) $response->getBody();
       if (empty($json)) {
         return FALSE;
-      } else {
+      }
+      else {
         $events = Json::decode($json)['events'];
         $current_page = Json::decode($json)['page']['current'];
         $total_pages = Json::decode($json)['page']['total'];
-        if(empty($events) || !$this->should_process_current_page($json,$current_page,$total_pages)) {
+        if (empty($events) || !$this->should_process_current_page($json, $current_page, $total_pages)) {
           \Drupal::logger('localist_pull')->notice("should not process page $current_page of $total_pages");
           return;
         }
         \Drupal::logger('localist_pull')->notice("process page $current_page of $total_pages");
-        if(!empty($events)) {
+        if (!empty($events)) {
           foreach ($events as $event) {
-            $localist_data_array = $this->get_localist_event_data($event,$this->create_node_create_array());
-            $existing_event = $this->get_node_by_localist_id($search_field_name,$event['event']['id']);
-            if(empty($existing_event)) {
+            $localist_data_array = $this->get_localist_event_data($event, $this->create_node_create_array());
+            $existing_event = $this->get_node_by_localist_id($search_field_name, $event['event']['id']);
+            if (empty($existing_event)) {
               $node = Node::create(
                 $localist_data_array
               );
-              if(!$this->config->publish_events_bool) {
+              if (!$this->config->publish_events_bool) {
                 $node->setUnpublished();
               }
               $node->save();
-            } else {
-              if($this->config->update_events_bool) {
-                $nid = reset($existing_event);
-                $node = Node::load($nid);
+            }
+            else {
+              if ($this->config->update_events_bool) {
+                // $nid = reset($existing_event);
+                // $node = Node::load($nid);
+                $temp = array_reverse($existing_event);
+                $existing_node_id = array_pop($temp);
+                $node = Node::load($existing_node_id);
                 foreach ($localist_data_array as $key => $value) {
-                  if($key != 'type') {
-                    $node->set($key,$value);
+                  if ($key != 'type') {
+                    $node->set($key, $value);
                   }
                 }
                 $node->save();
@@ -319,27 +359,27 @@ class LocalistProcessor {
 
         //recursive call until we hit localist_page_count limit if configured, max of 3 pages
         $next_page_url = $this->create_localist_url($current_page + 1);
-        $this->process_url_pull($search_field_name,$next_page_url);
+        $this->process_url_pull($search_field_name, $next_page_url);
       }
     }
     catch (RequestException $e) {
-      \Drupal::logger('localist_pull')->error($e->getMessage());
+      \Drupal::logger('localist_pull')->notice("exception");
       return FALSE;
     }
   }
 
-  private function should_process_current_page($json,$current_page,$total_pages) {
+  private function should_process_current_page($json, $current_page, $total_pages) {
     $pages_to_process = 1;
     $have_page_count = is_numeric($this->config->get('localist_page_count'));
-    if($have_page_count) {
-      $pages_to_process = min(($this->config->get('localist_page_count')),3);
+    if ($have_page_count) {
+      $pages_to_process = min(($this->config->get('localist_page_count')), 3);
     }
 
-    if($current_page > $pages_to_process) {
+    if ($current_page > $pages_to_process) {
       return false;
     }
 
-    if($current_page > $total_pages) {
+    if ($current_page > $total_pages) {
       return false;
     }
     return true;

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -5,6 +5,7 @@ namespace Drupal\cwd_events_localist_pull;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Component\Serialization\Json;
 use \Drupal\node\Entity\Node;
+use \Drupal\media\Entity\Media;
 use Drupal\taxonomy\Entity\Term;
 use GuzzleHttp\Exception\RequestException;
 
@@ -182,7 +183,7 @@ class LocalistProcessor {
   private function find_media_for_file($image_array) {
     $file = \Drupal::entityTypeManager()->getStorage('file')->load($image_array['target_id']);
     $result = \Drupal::service('file.usage')->listUsage($file);
-    if (array_key_exists('media', $result['file'])) {
+    if ($result && array_key_exists('media', $result['file'])) {
       return array_key_first($result['file']['media']);
     }
     else {

--- a/src/LocalistProcessor.php
+++ b/src/LocalistProcessor.php
@@ -374,7 +374,7 @@ class LocalistProcessor {
       }
     }
     catch (RequestException $e) {
-      \Drupal::logger('localist_pull')->notice("exception");
+      \Drupal::logger('localist_pull')->notice($e->getMessage());
       return FALSE;
     }
   }


### PR DESCRIPTION
Image to Media support

Replaces #43, which broke with 3.0 release of this module. See that PR for further discussion.


Adds additional configuration for new media field mapping to upgrade from image to media

- Configure an Media Image Field on your content type using the "Image" bundle of media
- Update "Localist event media field" on the localist config with the new field
- Remove "Localist event image field" on the localist config with the new field
- Run cron for new images

Before you run cron in order to move images from the image field to the media field for existing content 
`composer require cubear/cwd_field_to_media`

Enable cwd_field_to_media
Run
`drush cwd:convert-image CT_MACHINE_NAME IMAGE_FIELD_MACHINE_NAME MEDIA_FIELD_MACINE_NAME --dry-run`

If you like the output run the command without the --dry-run